### PR TITLE
Added function to load all relations.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,8 +110,15 @@ You can use both `include` and `include_count` parameters as string or as an arr
     }
     ```
     and then including it using either `www.example.com/profiles?include=social_media_accounts` or `www.example.com/profiles?include=socialMediaAccounts`
-    
-     
+
+
+### Load all relationships
+- If you want to load all relationships you can pass "**all**" to **include**:
+  ```php
+  ?include=all
+  ```
+
+
 ### Futher Explanations
 
 - Both `loadableRelations` and `loadableRelationsCount` arrays must be set on models which you want to to load their relations.

--- a/src/IncludeRelations.php
+++ b/src/IncludeRelations.php
@@ -45,7 +45,17 @@ trait IncludeRelations
         $includedRelations = DynamicRelationsIncludeRequest::getRequestIncludeParameter();
 
         if (is_array($includedRelations) && count($includedRelations) == 1 && $includedRelations[0] == 'all') {
-            $this->loadAllRelations();
+            $includedRelations = $this->loadableRelations;
+
+            if (is_array($includedRelations)) {
+                foreach ($includedRelations as $relation) {
+                    if (!$this->loadIfLoadableRelation($relation)) {
+                        $this->loadIfLoadableRelation(Str::camel($relation));
+                    }
+                    $includedRelations = $this->loadableRelations;
+                }
+            }
+
             return;
         }
 
@@ -77,17 +87,6 @@ trait IncludeRelations
                 }
             }, $includedRelationsCount);
         }
-    }
-
-    public function loadAllRelations()
-    {
-        if (is_array($this->loadableRelations)) {
-            foreach ($this->loadableRelations as $relation) {
-                $this->with[] = $relation;
-            }
-        }
-
-        return true;
     }
 
     public function loadIfLoadableRelation($relation)

--- a/src/IncludeRelations.php
+++ b/src/IncludeRelations.php
@@ -52,7 +52,6 @@ trait IncludeRelations
                     if (!$this->loadIfLoadableRelation($relation)) {
                         $this->loadIfLoadableRelation(Str::camel($relation));
                     }
-                    $includedRelations = $this->loadableRelations;
                 }
             }
 

--- a/src/IncludeRelations.php
+++ b/src/IncludeRelations.php
@@ -44,7 +44,7 @@ trait IncludeRelations
     {
         $includedRelations = DynamicRelationsIncludeRequest::getRequestIncludeParameter();
 
-        if (is_array($includedRelations) && count($includedRelations) == 1 && array_key_first($includedRelations) == 'all') {
+        if (is_array($includedRelations) && count($includedRelations) == 1 && $includedRelations[0] == 'all') {
             $this->loadAllRelations();
             return;
         }

--- a/src/IncludeRelations.php
+++ b/src/IncludeRelations.php
@@ -44,6 +44,11 @@ trait IncludeRelations
     {
         $includedRelations = DynamicRelationsIncludeRequest::getRequestIncludeParameter();
 
+        if (is_array($includedRelations) && count($includedRelations) == 1 && array_key_first($includedRelations) == 'all') {
+            $this->loadAllRelations();
+            return;
+        }
+
         if (is_array($includedRelations)) {
             array_map(function ($relation) {
                 if ($this->loadIfLoadableRelation($relation)) {
@@ -72,6 +77,17 @@ trait IncludeRelations
                 }
             }, $includedRelationsCount);
         }
+    }
+
+    public function loadAllRelations()
+    {
+        if (is_array($this->loadableRelations)) {
+            foreach ($this->loadableRelations as $relation) {
+                $this->with[] = $relation;
+            }
+        }
+
+        return true;
     }
 
     public function loadIfLoadableRelation($relation)


### PR DESCRIPTION
If we have so many relations it's hard to call every relation for example in Edit mode we need all relations.

So if wee pass to **include** parameter **all** `?include=all` all relations of Model will be loaded.